### PR TITLE
fix: force the use of webgl in puppeteer browser

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -105,7 +105,15 @@ async function collectBonus(token, page) {
 }
 
 (async () => {
-  const browser = await puppeteer.launch({ headless: false });
+  const browser = await puppeteer.launch({
+    headless: false,
+    args: [
+      '--no-sandbox',
+      '--use-gl=desktop',
+      '--enable-webgl',
+      '--ignore-gpu-blocklist'
+    ]
+  });
   const page = await browser.newPage();
 
   await page.goto('https://discord.com/login');


### PR DESCRIPTION
This PR forces the use of WebGL in puppeteer, which is required for the game to load

![Screenshot_2024-12-28-13-55-20_2174](https://github.com/user-attachments/assets/01dcd8d2-928a-498d-ab8e-f32efe6a589b)